### PR TITLE
Switch Entrypoint to CMD in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Table of Contents
 * [Usage](#usage)
 * [OPM](#opm)
 * [LuaRocks](#luarocks)
-* [Docker ENTRYPOINT](#docker-entrypoint)
+* [Docker CMD](#docker-entrypoint)
 * [Building (from source)](#building-from-source)
 * [Building (RPM based)](#building-rpm-based)
 * [Building (DEB based)](#building-deb-based)
@@ -107,12 +107,12 @@ It is available at `/usr/local/openresty/luajit/bin/luarocks`.  Packages can be 
 RUN /usr/local/openresty/luajit/bin/luarocks install <rock>
 ```
 
-Docker ENTRYPOINT
+Docker CMD
 =================
 
-The `-g "daemon off;"` directive is used in the Dockerfile ENTRYPOINT to keep the Nginx daemon running after container creation. If this directive is added to the nginx.conf, then it may be omitted from the ENTRYPOINT.
+The `-g "daemon off;"` directive is used in the Dockerfile CMD to keep the Nginx daemon running after container creation. If this directive is added to the nginx.conf, then it may be omitted from the CMD.
 
-To invoke with another ENTRYPOINT, for example the `resty` utility, invoke like so:
+To invoke with another CMD, for example the `resty` utility, invoke like so:
 
 ```
 docker run [options] --entrypoint /usr/local/openresty/bin/resty openresty/openresty:xenial [script.lua]
@@ -267,14 +267,14 @@ Changelog
 
  * Upgraded OpenResty to 1.11.2.1
  * Upgraded PCRE to 8.39
- * Updated ENTRYPOINT to use the new symlink `/usr/local/openresty/bin/openresty`
- * `centos-rpm` now has the build argument `RESTY_RPM_VERSION` and ENTRYPOINT `/usr/bin/openresty`
+ * Updated CMD to use the new symlink `/usr/local/openresty/bin/openresty`
+ * `centos-rpm` now has the build argument `RESTY_RPM_VERSION` and CMD `/usr/bin/openresty`
 
 ## 1.9.15.1
 
  * Upgraded OpenResty to 1.9.15.1
  * Logging is redirected to /dev/stdout and /dev/stderr
- * Introduced ENTRYPOINT with the `-g "daemon off;"` directive
+ * Introduced CMD with the `-g "daemon off;"` directive
  * Add `centos-rpm` base system, using upstream RPM packaging
 
 [Back to TOC](#table-of-contents)

--- a/README.md
+++ b/README.md
@@ -108,14 +108,14 @@ RUN /usr/local/openresty/luajit/bin/luarocks install <rock>
 ```
 
 Docker CMD
-=================
+============
 
 The `-g "daemon off;"` directive is used in the Dockerfile CMD to keep the Nginx daemon running after container creation. If this directive is added to the nginx.conf, then it may be omitted from the CMD.
 
 To invoke with another CMD, for example the `resty` utility, invoke like so:
 
 ```
-docker run [options] --entrypoint /usr/local/openresty/bin/resty openresty/openresty:xenial [script.lua]
+docker run [options] openresty/openresty:xenial /usr/local/openresty/bin/resty [script.lua]
 ```
 
 *NOTE* The `alpine` images do not include the packages `perl` and `ncurses`, which is needed by the `resty` utility.
@@ -267,14 +267,14 @@ Changelog
 
  * Upgraded OpenResty to 1.11.2.1
  * Upgraded PCRE to 8.39
- * Updated CMD to use the new symlink `/usr/local/openresty/bin/openresty`
- * `centos-rpm` now has the build argument `RESTY_RPM_VERSION` and CMD `/usr/bin/openresty`
+ * Updated ENTRYPOINT to use the new symlink `/usr/local/openresty/bin/openresty`
+ * `centos-rpm` now has the build argument `RESTY_RPM_VERSION` and ENTRYPOINT `/usr/bin/openresty`
 
 ## 1.9.15.1
 
  * Upgraded OpenResty to 1.9.15.1
  * Logging is redirected to /dev/stdout and /dev/stderr
- * Introduced CMD with the `-g "daemon off;"` directive
+ * Introduced ENTRYPOINT with the `-g "daemon off;"` directive
  * Add `centos-rpm` base system, using upstream RPM packaging
 
 [Back to TOC](#table-of-contents)

--- a/alpine-fat/Dockerfile
+++ b/alpine-fat/Dockerfile
@@ -111,4 +111,5 @@ RUN \
 # Add additional binaries into PATH for convenience
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
-ENTRYPOINT ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]
+CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]
+

--- a/alpine-fat/Dockerfile
+++ b/alpine-fat/Dockerfile
@@ -112,4 +112,3 @@ RUN \
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
 CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]
-

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -92,4 +92,4 @@ RUN \
 # Add additional binaries into PATH for convenience
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
-ENTRYPOINT ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]
+CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/armhf-xenial/Dockerfile
+++ b/armhf-xenial/Dockerfile
@@ -104,4 +104,4 @@ RUN \
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
 # TODO: remove any other apt packages?
-ENTRYPOINT ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]
+CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/centos-rpm/Dockerfile
+++ b/centos-rpm/Dockerfile
@@ -42,4 +42,4 @@ ARG RESTY_J="1"
 # Add additional binaries into PATH for convenience
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
-ENTRYPOINT ["/usr/bin/openresty", "-g", "daemon off;"]
+CMD ["/usr/bin/openresty", "-g", "daemon off;"]

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -100,4 +100,4 @@ RUN \
 # Add additional binaries into PATH for convenience
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
-ENTRYPOINT ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]
+CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -104,4 +104,4 @@ RUN \
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
 # TODO: remove any other apt packages?
-ENTRYPOINT ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]
+CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -39,4 +39,4 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
 # Add additional binaries into PATH for convenience
 ENV PATH="$PATH:/usr/local/openresty${RESTY_DEB_FLAVOR}/luajit/bin/:/usr/local/openresty${RESTY_DEB_FLAVOR}/nginx/sbin/:/usr/local/openresty${RESTY_DEB_FLAVOR}/bin/"
 
-ENTRYPOINT ["/usr/bin/openresty", "-g", "daemon off;"]
+CMD ["/usr/bin/openresty", "-g", "daemon off;"]

--- a/trusty/Dockerfile
+++ b/trusty/Dockerfile
@@ -104,4 +104,4 @@ RUN \
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
 # TODO: remove any other apt packages?
-ENTRYPOINT ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]
+CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -104,4 +104,4 @@ RUN \
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
 # TODO: remove any other apt packages?
-ENTRYPOINT ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]
+CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -104,4 +104,4 @@ RUN \
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
 # TODO: remove any other apt packages?
-ENTRYPOINT ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]
+CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]


### PR DESCRIPTION
the ENTRYPOINT directive in Docker is harder to overwrite like so for example:
```
docker run -it openresty/openresty sh
```

But with CMD instead, the functionality will remain the same while it makes it easier to overwrite the entrypoint for chaining containers together, debugging, running tests etc.