### PR TITLE
Added Test::Nginx to alpine-fat

### DIFF
--- a/alpine-fat/Dockerfile
+++ b/alpine-fat/Dockerfile
@@ -2,7 +2,8 @@
 # https://github.com/openresty/docker-openresty
 #
 # This is an alpine-based build that keeps some build-related
-# packages, has perl installed for opm, and includes luarocks.
+# packages, has perl installed for opm, Test::Nginx for testing,
+# and includes luarocks.
 
 FROM alpine:latest
 
@@ -74,6 +75,7 @@ RUN apk add --no-cache --virtual .build-deps \
         linux-headers \
         make \
         perl \
+        perl-dev \
         unzip \
         zlib \
     && cd /tmp \
@@ -104,6 +106,8 @@ RUN apk add --no-cache --virtual .build-deps \
         --with-lua-include=/usr/local/openresty/luajit/include/luajit-2.1 \
     && make build \
     && make install \
+    && curl -L http://cpanmin.us | perl - App::cpanminus --no-wget \
+    && cpanm Test::Nginx --no-wget \
     && cd /tmp \
     && rm -rf luarocks-${RESTY_LUAROCKS_VERSION} luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
     && apk add --no-cache --virtual .gettext gettext \


### PR DESCRIPTION
I recently discovered this excellent repo when trying to run Test::Nginx tests for my OpenResty project. Test::Nginx wasn't installed so I've gone ahead and added it.

I built an image from this Dockerfile and am able to run tests successfully (getting 'em passing is another matter!)

The current `alpine-fat` image is 234MB; this one is 259MB. So definitely a bit bigger. I still think it's in the spirit of fat to include all build utils, including tests.