### PR TITLE
fix:copy custom nginx.conf cause automated build failed

### DIFF
--- a/alpine-fat/Dockerfile
+++ b/alpine-fat/Dockerfile
@@ -125,7 +125,7 @@ RUN apk add --no-cache --virtual .build-deps \
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
 # Copy nginx configuration files
-COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
-COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
 CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -93,7 +93,7 @@ RUN apk add --no-cache --virtual .build-deps \
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
 # Copy nginx configuration files
-COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
-COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
 CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/armhf-xenial/Dockerfile
+++ b/armhf-xenial/Dockerfile
@@ -105,8 +105,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
 # Copy nginx configuration files
-COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
-COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
 # TODO: remove any other apt packages?
 CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/centos-rpm/Dockerfile
+++ b/centos-rpm/Dockerfile
@@ -45,7 +45,7 @@ ARG RESTY_J="1"
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
 # Copy nginx configuration files
-COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
-COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
 CMD ["/usr/bin/openresty", "-g", "daemon off;"]

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -102,7 +102,7 @@ RUN yum install -y \
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
 # Copy nginx configuration files
-COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
-COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
 CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -105,8 +105,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
 # Copy nginx configuration files
-COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
-COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
 # TODO: remove any other apt packages?
 CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -42,7 +42,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
 ENV PATH="$PATH:/usr/local/openresty${RESTY_DEB_FLAVOR}/luajit/bin/:/usr/local/openresty${RESTY_DEB_FLAVOR}/nginx/sbin/:/usr/local/openresty${RESTY_DEB_FLAVOR}/bin/"
 
 # Copy nginx configuration files
-COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
-COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
 CMD ["/usr/bin/openresty", "-g", "daemon off;"]

--- a/trusty/Dockerfile
+++ b/trusty/Dockerfile
@@ -105,8 +105,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
 # Copy nginx configuration files
-COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
-COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
 # TODO: remove any other apt packages?
 CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -105,8 +105,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
 # Copy nginx configuration files
-COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
-COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
 # TODO: remove any other apt packages?
 CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -105,8 +105,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
 
 # Copy nginx configuration files
-COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
-COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
 # TODO: remove any other apt packages?
 CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]


### PR DESCRIPTION
Fix when use docker-hub automated build, it's caused build failed:

```bash
Step 12/14 : COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf 

COPY failed: stat /var/lib/docker/tmp/docker-builder542158349/nginx.conf: no such file or directory

```