### PR TITLE
Add Dockerfile for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The following "flavors" are available:
 - [`stretch`, (*stretch/Dockerfile*)](https://github.com/openresty/docker-openresty/blob/master/stretch/Dockerfile)
 - [`trusty`, (*trusty/Dockerfile*)](https://github.com/openresty/docker-openresty/blob/master/trusty/Dockerfile)
 - [`wheezy`, (*wheezy/Dockerfile*)](https://github.com/openresty/docker-openresty/blob/master/wheezy/Dockerfile)
+- [`windows`, (*windows/Dockerfile*)](./windows/Dockerfile)
 - [`xenial`, (*xenial/Dockerfile*)](https://github.com/openresty/docker-openresty/blob/master/xenial/Dockerfile)
 
 
@@ -93,14 +94,14 @@ docker run [options] openresty/openresty:trusty
 
 *[options]* would be things like -p to map ports, -v to map volumes, and -d to daemonize.
 
-`docker-openresty` symlinks `/usr/local/openresty/nginx/logs/access.log` and `error.log` to `/dev/stdout` and `/dev/stderr` respectively, so that Docker logging works correctly.  If you change the log paths in your `nginx.conf`, you should symlink those paths as well.
+`docker-openresty` symlinks `/usr/local/openresty/nginx/logs/access.log` and `error.log` to `/dev/stdout` and `/dev/stderr` respectively, so that Docker logging works correctly.  If you change the log paths in your `nginx.conf`, you should symlink those paths as well. This is not possible with the `windows` image.
 
 nginx config files
 ==================
 
 The Docker tooling installs its own [`nginx.conf` file](https://github.com/openresty/docker-openresty/blob/master/nginx.conf).  If you want to directly override it, you can replace it in your own Dockerfile or via volume bind-mounting.
 
-That `nginx.conf` has the directive `include /etc/nginx/conf.d/*.conf;` so all nginx configurations in that directory will be included.  The [default virtual host configuration](https://github.com/openresty/docker-openresty/blob/master/nginx.vh.default.conf) has the original OpenResty configuration and is copied to `/etc/nginx/conf.d/default.conf`. 
+For the Linux images, that `nginx.conf` has the directive `include /etc/nginx/conf.d/*.conf;` so all nginx configurations in that directory will be included.  The [default virtual host configuration](https://github.com/openresty/docker-openresty/blob/master/nginx.vh.default.conf) has the original OpenResty configuration and is copied to `/etc/nginx/conf.d/default.conf`. 
 
 You can override that `default.conf` directly or volume bind-mount the `/etc/nginx/conf.d` directory to your own set of configurations:
 
@@ -108,10 +109,15 @@ You can override that `default.conf` directly or volume bind-mount the `/etc/ngi
 docker run -v /my/custom/conf.d:/etc/nginx/conf.d openresty/openresty:alpine
 ```
 
+When using the `windows` image you can change the main configuration directly:
+```
+docker run -v C:/my/custom/nginx.conf:C:/openresty/conf/nginx.conf openresty/openresty:windows
+```
+
 OPM
 ===
 
-Starting at version 1.11.2.2, OpenResty includes a [package manager called `opm`](https://github.com/openresty/opm#readme), which can be found at `/usr/local/openresty/bin/opm`.
+Starting at version 1.11.2.2, OpenResty for Linux includes a [package manager called `opm`](https://github.com/openresty/opm#readme), which can be found at `/usr/local/openresty/bin/opm`.
 
 `opm` is built in all the images except `alpine` and `stretch`.
 
@@ -135,7 +141,7 @@ RUN /usr/local/openresty/luajit/bin/luarocks install <rock>
 Tips & Pitfalls
 ===============
 
- * The `envsubst` utility is included in all images except `alpine`; this utility is also included
+ * The `envsubst` utility is included in all images except `alpine` and `windows`; this utility is also included
  in the Nginx docker image and is used to template environment variables into configuration files.
 
  * **Docker Hub** does not currently support ARM builds, thus the `armhf-xenial` image is not available. (See [#26](https://github.com/openresty/docker-openresty/pull/26))
@@ -149,7 +155,7 @@ docker build -f xenial/Dockerfile --build-arg "RESTY_CONFIG_OPTIONS_MORE=--with-
 Docker CMD
 ==========
 
-The `-g "daemon off;"` directive is used in the Dockerfile CMD to keep the Nginx daemon running after container creation. If this directive is added to the nginx.conf, then the `docker run` should explicitly invoke `openresty`:
+The `-g "daemon off;"` directive is used in the Dockerfile CMD to keep the Nginx daemon running after container creation. If this directive is added to the nginx.conf, then the `docker run` should explicitly invoke `openresty` (or `nginx` for `windows` images):
 ```
 docker run [options] openresty/openresty:xenial openresty
 ```
@@ -225,6 +231,25 @@ docker build --build-arg RESTY_RPM_FLAVOR="-debug" centos-rpm
 |RESTY_RPM_FLAVOR | "" | The `openresty` package flavor to use.  Possibly `"-debug"` or `"-valgrind"`. |
 |RESTY_RPM_VERSION | 1.11.2.5-1.el7.centos | The `openresty` package version to install. |
 |RESTY_RPM_ARCH | x86_64 | The `openresty` package architecture to install. |
+
+[Back to TOC](#table-of-contents)
+
+Building (Windows)
+====================
+
+This Docker image can be built and customized by cloning the repo and running `docker build` with the desired Dockerfile:
+
+ * [Windows](https://github.com/openresty/docker-openresty/blob/master/centos-rpm/Dockerfile) (`windows/Dockerfile`)
+
+The following are the available build-time options. They can be set using the `--build-arg` CLI argument, like so:
+
+```
+docker build --build-arg RESTY_VERSION="1.13.6.1" -f windows/Dockerfile .
+```
+
+| Key | Default | Description |
+:----- | :-----: |:----------- |
+|RESTY_VERSION | 1.13.6.1 | The version of OpenResty to use. |
 
 [Back to TOC](#table-of-contents)
 

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -1,12 +1,5 @@
 # Dockerfile - Windows
-
-FROM microsoft/windowsservercore AS base
-
-WORKDIR C:/openresty
-RUN setx /M PATH "%PATH%;C:\Strawberry\perl\bin;C:\openresty"
-
-CMD [ "nginx", "-g", "\"daemon off;\""]
-
+# https://github.com/openresty/docker-openresty
 
 FROM microsoft/windowsservercore as downloader
 
@@ -26,7 +19,15 @@ RUN Invoke-WebRequest -Uri "https://chocolatey.org/install.ps1" -UseBasicParsing
     mv .\openresty-*\ .\openresty ; 
 
 
-FROM base 
+FROM microsoft/windowsservercore
+
+LABEL maintainer="Evan Wies <evan@neomantra.net>"
+
+WORKDIR C:/openresty
+RUN setx /M PATH "%PATH%;C:\Strawberry\perl\bin;C:\openresty"
+
+CMD [ "nginx", "-g", "\"daemon off;\""]
+
 COPY --from=downloader C:/dl/ C:/
 
 # nginx config is not overwritten as paths in the Windows distribution are already fine

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -1,0 +1,32 @@
+# Dockerfile - Windows
+
+FROM microsoft/windowsservercore AS base
+
+WORKDIR C:/openresty
+RUN setx /M PATH "%PATH%;C:\Strawberry\perl\bin;C:\openresty"
+
+CMD [ "nginx", "-g", "\"daemon off;\""]
+
+
+FROM microsoft/windowsservercore as downloader
+
+ARG RESTY_VERSION="1.13.6.1"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+WORKDIR C:/dl
+
+# Download Perl and OpenResty
+RUN Invoke-WebRequest -Uri "https://chocolatey.org/install.ps1" -UseBasicParsing | iex ; \
+    choco install strawberryperl -y --no-progress ; \
+    mv C:\Strawberry\ C:\dl\ ; \
+    Write-Host "Downloading OpenResty.." ; \
+    Invoke-WebRequest "https://openresty.org/download/openresty-$($env:RESTY_VERSION)-win32.zip" -OutFile C:\openresty.zip ; \
+    Expand-Archive C:\openresty.zip . ; \
+    mv .\openresty-*\ .\openresty ; 
+
+
+FROM base 
+COPY --from=downloader C:/dl/ C:/
+
+# nginx config is not overwritten as paths in the Windows distribution are already fine


### PR DESCRIPTION
Adding Dockerfile for Windows. Unfortunately building OpenResty inside Docker during image build is currently not possible due to issues with MSYS2/Cygwin or similar environments (see https://github.com/docker/for-win/issues/262).

Instead the Dockerfile is using the prebuilt binaries for Windows and also installs Perl. You can try the image on Windows: 
```
docker pull lippertmarkus/openresty:windows
docker run lippertmarkus/openresty:windows
```

I would recommend AppVeyor for CI on Windows. It worked flawlessly in my tests, is free for open-source software and easy to integrate: 
- Example build: https://ci.appveyor.com/project/lippertmarkus/docker-openresty/build/1.0.14
- Used config: https://github.com/lippertmarkus/docker-openresty/blob/master/appveyor.yml

