### PR TITLE
Adding -y to apt-get cleanup

### DIFF
--- a/bionic/Dockerfile
+++ b/bionic/Dockerfile
@@ -120,7 +120,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && cd /tmp \
     && if [ -n "${RESTY_EVAL_POST_MAKE}" ]; then eval $(echo ${RESTY_EVAL_POST_MAKE}); fi \
     && rm -rf luarocks-${RESTY_LUAROCKS_VERSION} luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
-    && if [ -n "${RESTY_ADD_PACKAGE_BUILDDEPS}" ]; then DEBIAN_FRONTEND=noninteractive apt-get remove --purge "${RESTY_ADD_PACKAGE_BUILDDEPS}" ; fi \
+    && if [ -n "${RESTY_ADD_PACKAGE_BUILDDEPS}" ]; then DEBIAN_FRONTEND=noninteractive apt-get remove -y --purge "${RESTY_ADD_PACKAGE_BUILDDEPS}" ; fi \
     && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \
     && ln -sf /dev/stdout /usr/local/openresty/nginx/logs/access.log \
     && ln -sf /dev/stderr /usr/local/openresty/nginx/logs/error.log


### PR DESCRIPTION
Adding -y to prevent apt-get from asking for confirmation when removing build dependencies.

---  

Furthermore, we are using debian-slim for production images, would there be any recommended way of building these images? (Currently I have a full dockerfile, but thinking of using this as a base image with an ARG for the base image... any ideas? should I open an issue to discuss this?)