### PR TITLE
change alpine base image version  from 8 to 9

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/openresty/docker-openresty
 
 ARG RESTY_IMAGE_BASE="alpine"
-ARG RESTY_IMAGE_TAG="3.8"
+ARG RESTY_IMAGE_TAG="3.9"
 
 FROM ${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG}
 


### PR DESCRIPTION
There are so many significant update from alpine 8 to 9 some of them are

- Linux 4.19   this is LTS release (alpine 8 is using 4.14)

- Switch from LibreSSL to OpenSSL

