### PR TITLE
Fix missing declaration for symbol 'ngx_http_lua_ffi_exec_regex'

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -64,7 +64,7 @@ LABEL resty_eval_pre_configure="${RESTY_EVAL_PRE_CONFIGURE}"
 LABEL resty_eval_post_make="${RESTY_EVAL_POST_MAKE}"
 
 # These are not intended to be user-specified
-ARG _RESTY_CONFIG_DEPS="--with-openssl=/tmp/openssl-${RESTY_OPENSSL_VERSION} --with-pcre=/tmp/pcre-${RESTY_PCRE_VERSION}"
+ARG _RESTY_CONFIG_DEPS="--with-openssl=/tmp/openssl-${RESTY_OPENSSL_VERSION} --with-pcre"
 
 
 # 1) Install apk dependencies
@@ -100,6 +100,9 @@ RUN apk add --no-cache --virtual .build-deps \
     && tar xzf pcre-${RESTY_PCRE_VERSION}.tar.gz \
     && curl -fSL https://openresty.org/download/openresty-${RESTY_VERSION}.tar.gz -o openresty-${RESTY_VERSION}.tar.gz \
     && tar xzf openresty-${RESTY_VERSION}.tar.gz \
+    && cd /tmp/pcre-${RESTY_PCRE_VERSION} \
+    && ./configure --enable-jit --enable-utf --enable-unicode-properties \
+    && make && make install \
     && cd /tmp/openresty-${RESTY_VERSION} \
     && if [[ "1.1.1" == $(echo -e "${RESTY_OPENSSL_VERSION}\n1.1.1" | sort -V | head -n1) ]] ; then \
         echo 'patching Nginx for OpenSSL 1.1.1' \


### PR DESCRIPTION
Hi there

When I run with official image and test it, the 500 happened. because OR require pcre-dev in runtime. please review it. thx.

```
docker run --name or_re_test_1 --rm -p 9001:81 -v $(pwd)/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf openresty/openresty:alpine
172.17.0.1 - - [07/Jul/2019:12:41:55 +0000] "GET /re HTTP/1.1" 500 183 "-" "curl/7.58.0"
2019/07/07 12:41:55 [error] 6#6: *1 lua entry thread aborted: runtime error: /usr/local/openresty/lualib/ngx/re.lua:47: missing declaration for symbol 'ngx_http_lua_ffi_exec_regex'
stack traceback:
coroutine 0:
	[C]: in function 'require'
	content_by_lua(nginx.conf:24):2: in main chunk, client: 172.17.0.1, server: , request: "GET /re HTTP/1.1", host: "127.0.0.1:9001"
```

The nginx.conf
```
worker_processes  1;

events {
    worker_connections 4;
}

http {
    server {
        listen 81;

        location /re {
            content_by_lua_block {
                local ngx_re = require "ngx.re"

                local res, err = ngx_re.split("a,b,c,d", ",")
                if err then
                    ngx.log(ngx.ERR, "failed: ", err)
                    return
                end

                for i = 1, #res do
                    ngx.say(res[i])
                end
            }
        }
    }
}
```

