### PR TITLE
Adding -y to apt-get remove so it doesnt fail at confirmation

### DIFF
--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -160,7 +160,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && cd /tmp \
     && if [ -n "${RESTY_EVAL_POST_MAKE}" ]; then eval $(echo ${RESTY_EVAL_POST_MAKE}); fi \
     && rm -rf luarocks-${RESTY_LUAROCKS_VERSION} luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
-    && if [ -n "${RESTY_ADD_PACKAGE_BUILDDEPS}" ]; then DEBIAN_FRONTEND=noninteractive apt-get remove --purge ${RESTY_ADD_PACKAGE_BUILDDEPS} ; fi \
+    && if [ -n "${RESTY_ADD_PACKAGE_BUILDDEPS}" ]; then DEBIAN_FRONTEND=noninteractive apt-get remove -y --purge ${RESTY_ADD_PACKAGE_BUILDDEPS} ; fi \
     && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \
     && ln -sf /dev/stdout /usr/local/openresty/nginx/logs/access.log \
     && ln -sf /dev/stderr /usr/local/openresty/nginx/logs/error.log


### PR DESCRIPTION
When a "build package" is added (requirement for building an addon package), it is removed after the build process.  

This removal was missing a -y, and was therefore failing whenever RESTY_ADD_PACKAGE_BUILDDEPS was set (ex: RESTY_ADD_PACKAGE_BUILDDEPS="git"