### PR TITLE
Decrease size of stretch-fat image

### DIFF
--- a/stretch/Dockerfile.fat
+++ b/stretch/Dockerfile.fat
@@ -16,4 +16,5 @@ LABEL maintainer="Evan Wies <evan@neomantra.net>"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        openresty-opm
+        openresty-opm \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Removes apt index after openresty-opm installation to decrease image size by > 10 MB as it is done in the base image already.