### PR TITLE
Add debian buster image variant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -133,6 +133,48 @@ jobs:
           docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-stretch-fat ;
         fi
 
+    - stage: build docker image for flavor buster and buster-fat
+      script:
+      - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
+      - docker build -t openresty:buster -f buster/Dockerfile .
+      - if [[ "$TRAVIS_BRANCH" == "master" ]] ; then
+          echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
+          docker tag openresty:buster $DOCKER_ORG/openresty:buster &&
+          docker push $DOCKER_ORG/openresty:buster ;
+          echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
+          docker tag openresty:buster $DOCKER_ORG/openresty:latest &&
+          docker push $DOCKER_ORG/openresty:latest ;
+        fi
+      - if [[ "$TRAVIS_TAG" ]] ; then
+          TRAVIS_TAG_BASE=$(echo -n "$TRAVIS_TAG" | sed 's/-[0-9]$//g') ;
+          if [[ ( "$TRAVIS_TAG_BASE" ) && ( "$TRAVIS_TAG_BASE" != "$TRAVIS_TAG" ) ]] ; then
+            echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
+            docker tag openresty:buster $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-buster &&
+            docker push $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-buster ;
+          fi ;
+          echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
+          docker tag openresty:buster $DOCKER_ORG/openresty:$TRAVIS_TAG-buster &&
+          docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-buster ;
+        fi
+      - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
+      - docker build -t openresty:buster-fat -f buster/Dockerfile.fat .
+      - if [[ "$TRAVIS_BRANCH" == "master" ]] ; then
+          echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
+          docker tag openresty:buster-fat $DOCKER_ORG/openresty:buster-fat &&
+          docker push $DOCKER_ORG/openresty:buster-fat ;
+        fi
+      - if [[ "$TRAVIS_TAG" ]] ; then
+          TRAVIS_TAG_BASE=$(echo -n "$TRAVIS_TAG" | sed 's/-[0-9]$//g') ;
+          if [[ ( "$TRAVIS_TAG_BASE" ) && ( "$TRAVIS_TAG_BASE" != "$TRAVIS_TAG" ) ]] ; then
+            echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
+            docker tag openresty:buster-fat $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-buster-fat &&
+            docker push $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-buster-fat ;
+          fi ;
+          echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
+          docker tag openresty:buster-fat $DOCKER_ORG/openresty:$TRAVIS_TAG-buster-fat &&
+          docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-buster-fat ;
+        fi
+
     - stage: build docker image for flavor xenial
       script:
       - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The following "flavors" are available and built from [upstream OpenResty package
 - [`centos`, `centos-rpm`, (*centos/Dockerfile*)](https://github.com/openresty/docker-openresty/blob/master/centos/Dockerfile)
 - [`stretch`, (*stretch/Dockerfile*)](https://github.com/openresty/docker-openresty/blob/master/stretch/Dockerfile)
 - [`stretch-fat`, (*stretch/Dockerfile.fat*)](https://github.com/openresty/docker-openresty/blob/master/stretch/Dockerfile.fat)
+- [`buster`, (*buster/Dockerfile*)](https://github.com/openresty/docker-openresty/blob/master/buster/Dockerfile)
+- [`buster-fat`, (*buster/Dockerfile.fat*)](https://github.com/openresty/docker-openresty/blob/master/buster/Dockerfile.fat)
 - [`windows`, (*windows/Dockerfile*)](https://github.com/openresty/docker-openresty/blob/master/windows/Dockerfile)
 
 The following "flavors" are built from source and are intended for more advanced and custom usage, caveat emptor:
@@ -62,7 +64,7 @@ Usage
 If you are happy with the build defaults, then you can use the openresty image from the [Docker Hub](https://hub.docker.com/r/openresty/openresty/).  The image tags available there are listed at the top of this README.
 
 ```
-docker run [options] openresty/openresty:stretch-fat
+docker run [options] openresty/openresty:buster-fat
 ```
 
 *[options]* would be things like -p to map ports, -v to map volumes, and -d to daemonize.
@@ -77,7 +79,7 @@ Nginx Config Files
 
 The Docker tooling installs its own [`nginx.conf` file](https://github.com/openresty/docker-openresty/blob/master/nginx.conf).  If you want to directly override it, you can replace it in your own Dockerfile or via volume bind-mounting.
 
-For the Linux images, that `nginx.conf` has the directive `include /etc/nginx/conf.d/*.conf;` so all nginx configurations in that directory will be included.  The [default virtual host configuration](https://github.com/openresty/docker-openresty/blob/master/nginx.vh.default.conf) has the original OpenResty configuration and is copied to `/etc/nginx/conf.d/default.conf`. 
+For the Linux images, that `nginx.conf` has the directive `include /etc/nginx/conf.d/*.conf;` so all nginx configurations in that directory will be included.  The [default virtual host configuration](https://github.com/openresty/docker-openresty/blob/master/nginx.vh.default.conf) has the original OpenResty configuration and is copied to `/etc/nginx/conf.d/default.conf`.
 
 You can override that `default.conf` directly or volume bind-mount the `/etc/nginx/conf.d` directory to your own set of configurations:
 
@@ -96,11 +98,11 @@ OPM
 
 Starting at version 1.11.2.2, OpenResty for Linux includes a [package manager called `opm`](https://github.com/openresty/opm#readme), which can be found at `/usr/local/openresty/bin/opm`.
 
-`opm` is built in all the images except `alpine` and `stretch`.
+`opm` is built in all the images except `alpine`, `stretch` and `buster`.
 
 To use `opm` in the `alpine` image, you must also install the `curl` and `perl` packages; they are not included by default because they double the image size.  You may install them like so: `apk add --no-cache curl perl`.
 
-To use `opm` within the `stretch` image, you can either use the `stretch-fat` image or install the `openresty-opm` package in a custom build (which you would need to do to install your own `opm` packages anyway), as shown in [this example](https://github.com/openresty/docker-openresty/blob/master/stretch/Dockerfile.opm_example).
+To use `opm` within the `stretch` and `buster` image, you can either use the `stretch-fat`/`buster-fat` image or install the `openresty-opm` package in a custom build (which you would need to do to install your own `opm` packages anyway), as shown in [this example](https://github.com/openresty/docker-openresty/blob/master/stretch/Dockerfile.opm_example).
 
 
 LuaRocks
@@ -320,6 +322,7 @@ You can derive your own Docker images from this to install your own packages.  S
 This Docker image can be built and customized by cloning the repo and running `docker build` with the desired Dockerfile:
 
  * [Debian Stretch 9 DEB](https://github.com/openresty/docker-openresty/blob/master/stretch/Dockerfile) (`stretch/Dockerfile`)
+ * [Debian Buster 10 DEB](https://github.com/openresty/docker-openresty/blob/master/buster/Dockerfile) (`buster/Dockerfile`)
 
 The following are the available build-time options. They can be set using the `--build-arg` CLI argument, like so:
 

--- a/buster/Dockerfile
+++ b/buster/Dockerfile
@@ -1,0 +1,63 @@
+# Dockerfile - Debian 10 Buster - DEB version
+# https://github.com/openresty/docker-openresty
+
+ARG RESTY_IMAGE_BASE="debian"
+ARG RESTY_IMAGE_TAG="buster-slim"
+
+FROM ${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG}
+
+LABEL maintainer="Evan Wies <evan@neomantra.net>"
+
+# RESTY_DEB_FLAVOR build argument is used to select other
+# OpenResty Debian package variants.
+# For example: "-debug" or "-valgrind"
+ARG RESTY_DEB_FLAVOR=""
+ARG RESTY_DEB_VERSION="=1.15.8.2-1~buster1"
+ARG RESTY_IMAGE_BASE="debian"
+ARG RESTY_IMAGE_TAG="buster-slim"
+
+LABEL resty_image_base="${RESTY_IMAGE_BASE}"
+LABEL resty_image_tag="${RESTY_IMAGE_TAG}"
+LABEL resty_deb_flavor="${RESTY_DEB_FLAVOR}"
+LABEL resty_deb_version="${RESTY_DEB_VERSION}"
+
+# Volume for temporary files
+VOLUME ["/var/run/openresty"]
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gettext-base \
+        gnupg2 \
+        lsb-release \
+        software-properties-common \
+        wget \
+    && wget -qO /tmp/pubkey.gpg https://openresty.org/package/pubkey.gpg \
+    && DEBIAN_FRONTEND=noninteractive apt-key add /tmp/pubkey.gpg \
+    && rm /tmp/pubkey.gpg \
+    && DEBIAN_FRONTEND=noninteractive add-apt-repository -y "deb http://openresty.org/package/debian $(lsb_release -sc) openresty" \
+    && DEBIAN_FRONTEND=noninteractive apt-get remove -y --purge \
+        gnupg2 \
+        lsb-release \
+        software-properties-common \
+        wget \
+    && DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        openresty${RESTY_DEB_FLAVOR}${RESTY_DEB_VERSION} \
+    && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /dev/stdout /usr/local/openresty${RESTY_DEB_FLAVOR}/nginx/logs/access.log \
+    && ln -sf /dev/stderr /usr/local/openresty${RESTY_DEB_FLAVOR}/nginx/logs/error.log
+
+# Add additional binaries into PATH for convenience
+ENV PATH="$PATH:/usr/local/openresty${RESTY_DEB_FLAVOR}/luajit/bin:/usr/local/openresty${RESTY_DEB_FLAVOR}/nginx/sbin:/usr/local/openresty${RESTY_DEB_FLAVOR}/bin"
+
+# Copy nginx configuration files
+COPY nginx.conf /usr/local/openresty${RESTY_DEB_FLAVOR}/nginx/conf/nginx.conf
+COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
+
+CMD ["/usr/bin/openresty", "-g", "daemon off;"]
+
+# Use SIGQUIT instead of default SIGTERM to cleanly drain requests
+# See https://github.com/openresty/docker-openresty/blob/master/README.md#tips--pitfalls
+STOPSIGNAL SIGQUIT

--- a/buster/Dockerfile.fat
+++ b/buster/Dockerfile.fat
@@ -1,0 +1,20 @@
+# Dockerfile - Debian 10 Buster Fat - DEB version
+# https://github.com/openresty/docker-openresty
+#
+# This builds upon the base OpenResty Buster image,
+# adding useful packages and utilities.
+#
+# Currently it just adds the openresty-opm package.
+#
+
+ARG RESTY_IMAGE_BASE="openresty/openresty"
+ARG RESTY_IMAGE_TAG="buster"
+
+FROM ${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG}
+
+LABEL maintainer="Evan Wies <evan@neomantra.net>"
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        openresty-opm \
+    && rm -rf /var/lib/apt/lists/*

--- a/gen_travis.lua
+++ b/gen_travis.lua
@@ -25,6 +25,7 @@ print(template({
         "centos-rpm",
         "jessie",
         "stretch",
+        "buster",
         "trusty",
         "wheezy",
         "xenial"


### PR DESCRIPTION
Adds buster image variant based on stretch Dockerfiles.
Note that changes to `.travis.yml` are untested