### PR TITLE
Remove build steps and add arm64 build for alpine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ services:
 
 jobs:
   include:
-
-    - stage: build docker image for flavors alpine and alpine-fat
+    - name: build docker image for arm64 flavors alpine and alpine-fat
+      arch: amd64
       script:
       - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
       - docker build -t openresty:alpine -f alpine/Dockerfile .
@@ -65,7 +65,47 @@ jobs:
           docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-fat ;
         fi
 
-    - stage: build docker image for flavor alpine-apk
+    - name: build docker image for arm64 flavors alpine and alpine-fat
+      arch: arm64
+      script:
+      - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
+      - docker build -t openresty:alpine -f alpine/Dockerfile .
+      - if [[ "$TRAVIS_BRANCH" == "master" ]] ; then
+          echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
+          docker tag openresty:alpine $DOCKER_ORG/openresty:alpine &&
+          docker push $DOCKER_ORG/openresty:alpine ;
+        fi
+      - if [[ "$TRAVIS_TAG" ]] ; then
+          TRAVIS_TAG_BASE=$(echo -n "$TRAVIS_TAG" | sed 's/-[0-9]$//g') ;
+          if [[ ( "$TRAVIS_TAG_BASE" ) && ( "$TRAVIS_TAG_BASE" != "$TRAVIS_TAG" ) ]] ; then
+            echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
+            docker tag openresty:alpine $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine &&
+            docker push $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine ;
+          fi ;
+          echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
+          docker tag openresty:alpine $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine &&
+          docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine ;
+        fi
+      - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
+      - docker build -t openresty:alpine-fat -f alpine/Dockerfile.fat .
+      - if [[ "$TRAVIS_BRANCH" == "master" ]] ; then
+          echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
+          docker tag openresty:alpine-fat $DOCKER_ORG/openresty:alpine-fat &&
+          docker push $DOCKER_ORG/openresty:alpine-fat ;
+        fi
+      - if [[ "$TRAVIS_TAG" ]] ; then
+          TRAVIS_TAG_BASE=$(echo -n "$TRAVIS_TAG" | sed 's/-[0-9]$//g') ;
+          if [[ ( "$TRAVIS_TAG_BASE" ) && ( "$TRAVIS_TAG_BASE" != "$TRAVIS_TAG" ) ]] ; then
+            echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
+            docker tag openresty:alpine-fat $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine-fat &&
+            docker push $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine-fat ;
+          fi ;
+          echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
+          docker tag openresty:alpine-fat $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-fat &&
+          docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-fat ;
+        fi
+
+    - name: build docker image for flavor alpine-apk
       script:
       - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
       - docker build -t openresty:alpine-apk -f alpine-apk/Dockerfile .
@@ -87,7 +127,7 @@ jobs:
         fi
 
     # aliased as `centos-rpm`
-    - stage: build docker image for flavor centos
+    - name: build docker image for flavor centos
       script:
       - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
       - docker build -t openresty:centos -f centos/Dockerfile .
@@ -114,7 +154,7 @@ jobs:
           docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-centos-rpm ;
         fi
 
-    - stage: build docker image for flavor Amazon Linux (amzn2)
+    - name: build docker image for flavor Amazon Linux (amzn2)
       script:
       - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
       - docker build -t openresty:amzn2 --build-arg RESTY_IMAGE_BASE=amazonlinux --build-arg RESTY_IMAGE_TAG=2 --build-arg RESTY_YUM_REPO="https://openresty.org/package/amazon/openresty.repo" --build-arg RESTY_RPM_DIST="amzn2" -f centos/Dockerfile .
@@ -135,7 +175,7 @@ jobs:
           docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-amzn2 ;
         fi
 
-    - stage: build docker image for flavor buster and buster-fat
+    - name: build docker image for flavor buster and buster-fat
       script:
       - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
       - docker build -t openresty:buster -f buster/Dockerfile .
@@ -177,7 +217,7 @@ jobs:
           docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-buster-fat ;
         fi
 
-    - stage: build docker image for flavor bionic
+    - name: build docker image for flavor bionic
       script:
       - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
       - docker build -t openresty:bionic -f bionic/Dockerfile .
@@ -198,7 +238,7 @@ jobs:
           docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-bionic ;
         fi
 
-    - stage: build docker image for flavor focal
+    - name: build docker image for flavor focal
       script:
       - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
       - docker build -t openresty:focal -f focal/Dockerfile .
@@ -219,7 +259,7 @@ jobs:
           docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-focal ;
         fi
 
-    - stage: build docker image for flavors alpine-nosse42 and alpine-fat-nosse42
+    - name: build docker image for flavors alpine-nosse42 and alpine-fat-nosse42
       script:
       - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
       - docker build -t openresty:alpine-nosse42 -f alpine/Dockerfile --build-arg RESTY_LUAJIT_OPTIONS="--with-luajit-xcflags='-DLUAJIT_NUMMODE=2 -DLUAJIT_ENABLE_LUA52COMPAT -mno-sse4.2'" .
@@ -258,7 +298,7 @@ jobs:
           docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-fat-nosse42 ;
         fi
 
-    - stage: build docker image for flavor bionic-nosse42
+    - name: build docker image for flavor bionic-nosse42
       script:
       - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
       - docker build -t openresty:bionic-nosse42 -f bionic/Dockerfile --build-arg RESTY_LUAJIT_OPTIONS="--with-luajit-xcflags='-DLUAJIT_NUMMODE=2 -DLUAJIT_ENABLE_LUA52COMPAT -mno-sse4.2'" .
@@ -279,7 +319,7 @@ jobs:
           docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-bionic-nosse42 ;
         fi
 
-    - stage: build docker image for flavor focal-nosse42
+    - name: build docker image for flavor focal-nosse42
       script:
       - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
       - docker build -t openresty:focal-nosse42 -f focal/Dockerfile --build-arg RESTY_LUAJIT_OPTIONS="--with-luajit-xcflags='-DLUAJIT_NUMMODE=2 -DLUAJIT_ENABLE_LUA52COMPAT -mno-sse4.2'" .
@@ -299,9 +339,9 @@ jobs:
           docker tag openresty:focal-nosse42 $DOCKER_ORG/openresty:$TRAVIS_TAG-focal-nosse42 &&
           docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-focal-nosse42 ;
         fi
-        
+
     # aliased as `fedora-rpm`
-    - stage: build docker image for flavor fedora
+    - name: build docker image for flavor fedora
       script:
       - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
       - docker build -t openresty:fedora -f fedora/Dockerfile .

--- a/.travis.yml
+++ b/.travis.yml
@@ -368,11 +368,11 @@ jobs:
           docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-fedora-rpm ;
         fi
 
-      - stage: push manifests for multi-arch builds
-        script:
-        - export DOCKER_CLI_EXPERIMENTAL=enabled
-        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        - docker manifest create $DOCKER_USERNAME/openresty:alpine --amend $DOCKER_USERNAME/openresty:alpine-amd64 --amend $DOCKER_USERNAME/openresty:alpine-arm64v8
-        - docker manifest push $DOCKER_USERNAME/openresty:alpine
-        - docker manifest create $DOCKER_USERNAME/openresty:alpine-fat --amend $DOCKER_USERNAME/openresty:alpine-fat-amd64 --amend $DOCKER_USERNAME/openresty:alpine-fat-arm64v8
-        - docker manifest push $DOCKER_USERNAME/openresty:alpine-fat
+    - stage: push manifests for multi-arch builds
+      script:
+      - export DOCKER_CLI_EXPERIMENTAL=enabled
+      - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+      - docker manifest create $DOCKER_USERNAME/openresty:alpine --amend $DOCKER_USERNAME/openresty:alpine-amd64 --amend $DOCKER_USERNAME/openresty:alpine-arm64v8
+      - docker manifest push $DOCKER_USERNAME/openresty:alpine
+      - docker manifest create $DOCKER_USERNAME/openresty:alpine-fat --amend $DOCKER_USERNAME/openresty:alpine-fat-amd64 --amend $DOCKER_USERNAME/openresty:alpine-fat-arm64v8
+      - docker manifest push $DOCKER_USERNAME/openresty:alpine-fat

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,80 +29,80 @@ jobs:
       arch: amd64
       script:
       - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
-      - docker build -t openresty:alpine -f alpine/Dockerfile .
+      - docker build -t openresty:alpine-amd64 -f alpine/Dockerfile .
       - if [[ "$TRAVIS_BRANCH" == "master" ]] ; then
           echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
-          docker tag openresty:alpine $DOCKER_ORG/openresty:alpine &&
-          docker push $DOCKER_ORG/openresty:alpine ;
+          docker tag openresty:alpine-amd64 $DOCKER_ORG/openresty:alpine-amd64 &&
+          docker push $DOCKER_ORG/openresty:alpine-amd64 ;
         fi
       - if [[ "$TRAVIS_TAG" ]] ; then
           TRAVIS_TAG_BASE=$(echo -n "$TRAVIS_TAG" | sed 's/-[0-9]$//g') ;
           if [[ ( "$TRAVIS_TAG_BASE" ) && ( "$TRAVIS_TAG_BASE" != "$TRAVIS_TAG" ) ]] ; then
             echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
-            docker tag openresty:alpine $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine &&
-            docker push $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine ;
+            docker tag openresty:alpine-amd64 $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine-amd64 &&
+            docker push $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine-amd64 ;
           fi ;
           echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
-          docker tag openresty:alpine $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine &&
-          docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine ;
+          docker tag openresty:alpine-amd64 $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-amd64 &&
+          docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-amd64 ;
         fi
       - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
-      - docker build -t openresty:alpine-fat -f alpine/Dockerfile.fat .
+      - docker build -t openresty:alpine-fat-amd64 -f alpine/Dockerfile.fat .
       - if [[ "$TRAVIS_BRANCH" == "master" ]] ; then
           echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
-          docker tag openresty:alpine-fat $DOCKER_ORG/openresty:alpine-fat &&
-          docker push $DOCKER_ORG/openresty:alpine-fat ;
+          docker tag openresty:alpine-fat-amd64 $DOCKER_ORG/openresty:alpine-fat-amd64 &&
+          docker push $DOCKER_ORG/openresty:alpine-fat-amd64 ;
         fi
       - if [[ "$TRAVIS_TAG" ]] ; then
           TRAVIS_TAG_BASE=$(echo -n "$TRAVIS_TAG" | sed 's/-[0-9]$//g') ;
           if [[ ( "$TRAVIS_TAG_BASE" ) && ( "$TRAVIS_TAG_BASE" != "$TRAVIS_TAG" ) ]] ; then
             echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
-            docker tag openresty:alpine-fat $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine-fat &&
-            docker push $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine-fat ;
+            docker tag openresty:alpine-fat-amd64 $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine-fat-amd64 &&
+            docker push $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine-fat-amd64 ;
           fi ;
           echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
-          docker tag openresty:alpine-fat $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-fat &&
-          docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-fat ;
+          docker tag openresty:alpine-fat-amd64 $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-fat-amd64 &&
+          docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-fat-amd64 ;
         fi
 
     - name: build docker image for arm64 flavors alpine and alpine-fat
       arch: arm64
       script:
       - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
-      - docker build -t openresty:alpine -f alpine/Dockerfile .
+      - docker build -t openresty:alpine-arm64v8 -f alpine/Dockerfile .
       - if [[ "$TRAVIS_BRANCH" == "master" ]] ; then
           echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
-          docker tag openresty:alpine $DOCKER_ORG/openresty:alpine &&
-          docker push $DOCKER_ORG/openresty:alpine ;
+          docker tag openresty:alpine-arm64v8 $DOCKER_ORG/openresty:alpine-arm64v8 &&
+          docker push $DOCKER_ORG/openresty:alpine-arm64v8 ;
         fi
       - if [[ "$TRAVIS_TAG" ]] ; then
           TRAVIS_TAG_BASE=$(echo -n "$TRAVIS_TAG" | sed 's/-[0-9]$//g') ;
           if [[ ( "$TRAVIS_TAG_BASE" ) && ( "$TRAVIS_TAG_BASE" != "$TRAVIS_TAG" ) ]] ; then
             echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
-            docker tag openresty:alpine $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine &&
-            docker push $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine ;
+            docker tag openresty:alpine-arm64v8 $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine-arm64v8 &&
+            docker push $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine-arm64v8 ;
           fi ;
           echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
-          docker tag openresty:alpine $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine &&
-          docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine ;
+          docker tag openresty:alpine-arm64v8 $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-arm64v8 &&
+          docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-arm64v8 ;
         fi
       - echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
-      - docker build -t openresty:alpine-fat -f alpine/Dockerfile.fat .
+      - docker build -t openresty:alpine-fat-arm64v8 -f alpine/Dockerfile.fat .
       - if [[ "$TRAVIS_BRANCH" == "master" ]] ; then
           echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
-          docker tag openresty:alpine-fat $DOCKER_ORG/openresty:alpine-fat &&
-          docker push $DOCKER_ORG/openresty:alpine-fat ;
+          docker tag openresty:alpine-fat-arm64v8 $DOCKER_ORG/openresty:alpine-fat-arm64v8 &&
+          docker push $DOCKER_ORG/openresty:alpine-fat-arm64v8 ;
         fi
       - if [[ "$TRAVIS_TAG" ]] ; then
           TRAVIS_TAG_BASE=$(echo -n "$TRAVIS_TAG" | sed 's/-[0-9]$//g') ;
           if [[ ( "$TRAVIS_TAG_BASE" ) && ( "$TRAVIS_TAG_BASE" != "$TRAVIS_TAG" ) ]] ; then
             echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
-            docker tag openresty:alpine-fat $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine-fat &&
-            docker push $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine-fat ;
+            docker tag openresty:alpine-fat-arm64v8 $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine-fat-arm64v8 &&
+            docker push $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine-fat-arm64v8 ;
           fi ;
           echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
-          docker tag openresty:alpine-fat $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-fat &&
-          docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-fat ;
+          docker tag openresty:alpine-fat-arm64v8 $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-fat-arm64v8 &&
+          docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-fat-arm64v8 ;
         fi
 
     - name: build docker image for flavor alpine-apk
@@ -367,3 +367,12 @@ jobs:
           docker tag $DOCKER_ORG/openresty:$TRAVIS_TAG-fedora $DOCKER_ORG/openresty:$TRAVIS_TAG-fedora-rpm &&
           docker push $DOCKER_ORG/openresty:$TRAVIS_TAG-fedora-rpm ;
         fi
+
+      - stage: push manifests for multi-arch builds
+        script:
+        - export DOCKER_CLI_EXPERIMENTAL=enabled
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - docker manifest create $DOCKER_USERNAME/openresty:alpine --amend $DOCKER_USERNAME/openresty:alpine-amd64 --amend $DOCKER_USERNAME/openresty:alpine-arm64v8
+        - docker manifest push $DOCKER_USERNAME/openresty:alpine
+        - docker manifest create $DOCKER_USERNAME/openresty:alpine-fat --amend $DOCKER_USERNAME/openresty:alpine-fat-amd64 --amend $DOCKER_USERNAME/openresty:alpine-fat-arm64v8
+        - docker manifest push $DOCKER_USERNAME/openresty:alpine-fat

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,3 +13,4 @@ We'd like to thank the following people for their commits:
 - Robin Ketelbuters <robin.ketelbuters@gmail.com>
 - Joel Linn <jl@conductive.de>
 - Kshitij Joshi <kshitijmjoshi@gmail.com>
+- Duncan Schulze <duschulze@gmail.com>

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The following "flavors" are available and built from [upstream OpenResty package
 
 The following "flavors" are built from source and are intended for more advanced and custom usage, caveat emptor:
 
-- [`alpine`, (*alpine/Dockerfile*)](https://github.com/openresty/docker-openresty/blob/master/alpine/Dockerfile)
-- [`alpine-fat`, (*alpine/Dockerfile.fat*)](https://github.com/openresty/docker-openresty/blob/master/alpine/Dockerfile.fat)
+- [`alpine`, (*alpine/Dockerfile*)](https://github.com/openresty/docker-openresty/blob/master/alpine/Dockerfile) - AMD64 and ARM64v8
+- [`alpine-fat`, (*alpine/Dockerfile.fat*)](https://github.com/openresty/docker-openresty/blob/master/alpine/Dockerfile.fat) - AMD64 and ARM64v8
 - [`bionic`, (*bionic/Dockerfile*)](https://github.com/openresty/docker-openresty/blob/master/bionic/Dockerfile)
 - [`focal`, (*focal/Dockerfile*)](https://github.com/openresty/docker-openresty/blob/master/focal/Dockerfile)
 
@@ -26,6 +26,8 @@ Starting with `1.13.6.1`, releases are tagged with `<openresty-version>-<image-v
 Starting with `1.15.8.1`, there are also `-nosse42` image flavors for systems which do not support SSE 4.2 (e.g. older systems and embedded systems).  They are built with `-mno-sse4.2` appended to the build arg `RESTY_LUAJIT_OPTIONS`.  It is highly recommended *NOT* to use these if your system supports SSE 4.2 because the `CRC32` instruction dramatically improves large string performance.  These are only for built-from-source flavors, e.g. `1.15.8.1-3-bionic-nosse42`, `1.15.8.1-3-alpine-nosse42`, `1.15.8.1-3-alpine-fat-nosse42`.
 
 It is *highly recommended* that you use the upstream-based images for best support.  For best stability, pin your images to the full tag, for example `1.17.8.1-0-bionic`.
+
+At this time, the only images that are compatible with ARM64v8 are alpine and alpine-fat.  Once there are binary packages available, they can be released with the upstream packages.
 
 
 Table of Contents


### PR DESCRIPTION
I don't believe that each build actually depends on those before it, removing `stage` allows them all to run at once if nodes are available.