### PR TITLE
Upgrade alpine images to 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## Unreleased
+
+ * Bump `alpine` to 3.12 to address CVE-2019-2201
+
 ## 1.17.8.2-3
 
  * Multi-architecture builds for `alpine`, supporting `amd64` and `arm64v8` (#130, #157)
@@ -44,7 +48,7 @@ Changelog
 
 * Upgrade OpenResty to 1.15.8.3
 * Windows builds now use `servercore:ltsc2019` and `nanoserver:1809`
- 
+
 ## 1.15.8.2-7
 
  * Add `buster-nosse2` and `buster-fat-nosse2` (#103)
@@ -52,7 +56,7 @@ Changelog
 
 ## 1.15.8.2-6
 
- * Add `RESTY_YUM_REPO` and `RESTY_RPM_DIST` build args to `centos` 
+ * Add `RESTY_YUM_REPO` and `RESTY_RPM_DIST` build args to `centos`
  * Install more yum packages for `centos` builds
  * Add `amzn2` flavor, based on `centos`
 
@@ -133,8 +137,8 @@ For now (untagged release), the following only applies to built-from-source flav
  * Upgrade Openresty to 1.15.8.1rc1
  * Upgrade LuaRocks to 3.0.4
  * Upgrade OpenSSL to 1.0.2r / 1.1.0j
- 
- * Temporarily disable Travis builds of centos / stretch images 
+
+ * Temporarily disable Travis builds of centos / stretch images
    until upstream packages are available
 
 ## 1.13.6.2-2
@@ -166,7 +170,7 @@ For now (untagged release), the following only applies to built-from-source flav
 
     * `centos-rpm` renamed to `centos`.  `centos-rpm` tag works but is deprecated.
 
-    * Archive `armhf-xenial`, `centos`, `jessie`, `trusty`, `wheezy` 
+    * Archive `armhf-xenial`, `centos`, `jessie`, `trusty`, `wheezy`
 
     * `alpine-fat` is now built on top of `alpine` rather than standalone
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ docker build --build-arg RESTY_J=4 -f bionic/Dockerfile .
 | Key | Default | Description |
 :----- | :-----: |:----------- |
 |RESTY_IMAGE_BASE | "ubuntu" / "alpine" | The Debian or Alpine Docker image base to build `FROM`. |
-|RESTY_IMAGE_TAG  | "bionic" / "3.11" | The Debian or Alpine Docker image tag to build `FROM`. |
+|RESTY_IMAGE_TAG  | "bionic" / "3.12" | The Debian or Alpine Docker image tag to build `FROM`. |
 |RESTY_VERSION | 1.17.8.2 | The version of OpenResty to use. |
 |RESTY_LUAROCKS_VERSION | 3.3.1 | The version of LuaRocks to use. |
 |RESTY_OPENSSL_VERSION | 1.1.1g | The version of OpenSSL to use. |
@@ -379,13 +379,13 @@ This Docker image can be built and customized by cloning the repo and running `d
 The following are the available build-time options. They can be set using the `--build-arg` CLI argument, like so:
 
 ```
-docker build --build-arg RESTY_IMAGE_TAG="3.11" -f alpine-apk/Dockerfile .
+docker build --build-arg RESTY_IMAGE_TAG="3.12" -f alpine-apk/Dockerfile .
 ```
 
 | Key | Default | Description |
 :----- | :-----: |:----------- |
 |RESTY_IMAGE_BASE   | "alpine" | The Alpine Docker image base to build `FROM`. |
-|RESTY_IMAGE_TAG    | "3.11" | The Alpine Docker image tag to build `FROM`. |
+|RESTY_IMAGE_TAG    | "3.12" | The Alpine Docker image tag to build `FROM`. |
 |RESTY_APK_KEY_URL  | "http://openresty.org/package/admin@openresty.com-5ea678a6.rsa.pub" | The URL of the signing key of the `openresty` package. |
 |RESTY_APK_REPO_URL | "http://openresty.org/package/alpine/v${RESTY_IMAGE_TAG}/main" | The URL of the APK repository for `openresty` package. |
 |RESTY_APK_VERSION | "=1.17.8.2-r0" | The suffix to add to the apk instaalpackage name: `openresty${RESTY_APK_VERSION`}. |

--- a/alpine-apk/Dockerfile
+++ b/alpine-apk/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/openresty/docker-openresty
 
 ARG RESTY_IMAGE_BASE="alpine"
-ARG RESTY_IMAGE_TAG="3.11"
+ARG RESTY_IMAGE_TAG="3.12"
 
 FROM ${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG}
 
@@ -10,7 +10,7 @@ LABEL maintainer="Evan Wies <evan@neomantra.net>"
 
 # Docker Build Arguments
 ARG RESTY_IMAGE_BASE="alpine"
-ARG RESTY_IMAGE_TAG="3.11"
+ARG RESTY_IMAGE_TAG="3.12"
 
 ARG RESTY_APK_KEY_URL="http://openresty.org/package/admin@openresty.com-5ea678a6.rsa.pub"
 ARG RESTY_APK_REPO_URL="http://openresty.org/package/alpine/v${RESTY_IMAGE_TAG}/main"

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/openresty/docker-openresty
 
 ARG RESTY_IMAGE_BASE="alpine"
-ARG RESTY_IMAGE_TAG="3.11"
+ARG RESTY_IMAGE_TAG="3.12"
 
 FROM ${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG}
 
@@ -10,7 +10,7 @@ LABEL maintainer="Evan Wies <evan@neomantra.net>"
 
 # Docker Build Arguments
 ARG RESTY_IMAGE_BASE="alpine"
-ARG RESTY_IMAGE_TAG="3.11"
+ARG RESTY_IMAGE_TAG="3.12"
 ARG RESTY_VERSION="1.17.8.2"
 ARG RESTY_OPENSSL_VERSION="1.1.1g"
 ARG RESTY_OPENSSL_PATCH_VERSION="1.1.1f"


### PR DESCRIPTION
Addresses CVE-2019-2201 https://nvd.nist.gov/vuln/detail/CVE-2019-2201