### PR TITLE
Fix alpine manifest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -401,7 +401,7 @@ jobs:
             docker manifest create $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine-fat --amend $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine-fat-amd64 --amend $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine-fat-arm64v8 &&
             docker manifest push $DOCKER_ORG/openresty:$TRAVIS_TAG_BASE-alpine-fat ;
           fi ;
-          docker manifest create $DOCKER_ORG/$TRAVIS_TAG-openresty:alpine --amend $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-amd64 --amend $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-arm64v8 &&
+          docker manifest create $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine --amend $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-amd64 --amend $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-arm64v8 &&
           docker manifest push $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine ;
           docker manifest create $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-fat --amend $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-fat-amd64 --amend $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-fat-arm64v8 &&
           docker manifest push $DOCKER_ORG/openresty:$TRAVIS_TAG-alpine-fat ;


### PR DESCRIPTION
In the last master build the manifest pushing failed https://travis-ci.org/github/openresty/docker-openresty/jobs/725404100#L235 as the manifest was created with a wrong name and there is also no `openresty/openresty:1.17.8.2-4-alpine` on docker hub https://hub.docker.com/r/openresty/openresty/tags?page=1&name=1.17.8.2-4-alpine&ordering=-name

Not sure why the build didn't fail, but this should resolve the issue.