### PR TITLE
Upgrade alpine version to 3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 ## Untagged
 
- * Upgrade `alpine` to Alpine 3.13.   `alpine-apk` is still at Alpine 3.12.
+ * Bump `alpine` and `alpine-apk` to 3.13
  * Upgrade LuaRocks to 3.5.0
  
 ## 1.19.3.1-2

--- a/README.md
+++ b/README.md
@@ -379,13 +379,13 @@ This Docker image can be built and customized by cloning the repo and running `d
 The following are the available build-time options. They can be set using the `--build-arg` CLI argument, like so:
 
 ```
-docker build --build-arg RESTY_IMAGE_TAG="3.12" -f alpine-apk/Dockerfile .
+docker build --build-arg RESTY_IMAGE_TAG="3.13" -f alpine-apk/Dockerfile .
 ```
 
 | Key | Default | Description |
 :----- | :-----: |:----------- |
 |RESTY_IMAGE_BASE   | "alpine" | The Alpine Docker image base to build `FROM`. |
-|RESTY_IMAGE_TAG    | "3.12" | The Alpine Docker image tag to build `FROM`. |
+|RESTY_IMAGE_TAG    | "3.13" | The Alpine Docker image tag to build `FROM`. |
 |RESTY_APK_KEY_URL  | "http://openresty.org/package/admin@openresty.com-5ea678a6.rsa.pub" | The URL of the signing key of the `openresty` package. |
 |RESTY_APK_REPO_URL | "http://openresty.org/package/alpine/v${RESTY_IMAGE_TAG}/main" | The URL of the APK repository for `openresty` package. |
 |RESTY_APK_VERSION | "=1.19.3.1-r0" | The suffix to add to the apk instaalpackage name: `openresty${RESTY_APK_VERSION`}. |

--- a/alpine-apk/Dockerfile
+++ b/alpine-apk/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/openresty/docker-openresty
 
 ARG RESTY_IMAGE_BASE="alpine"
-ARG RESTY_IMAGE_TAG="3.12"
+ARG RESTY_IMAGE_TAG="3.13"
 
 FROM ${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG}
 
@@ -10,7 +10,7 @@ LABEL maintainer="Evan Wies <evan@neomantra.net>"
 
 # Docker Build Arguments
 ARG RESTY_IMAGE_BASE="alpine"
-ARG RESTY_IMAGE_TAG="3.12"
+ARG RESTY_IMAGE_TAG="3.13"
 
 ARG RESTY_APK_KEY_URL="http://openresty.org/package/admin@openresty.com-5ea678a6.rsa.pub"
 ARG RESTY_APK_REPO_URL="http://openresty.org/package/alpine/v${RESTY_IMAGE_TAG}/main"


### PR DESCRIPTION
This is based on #159, but it is not finished since this line won't resolve for 3.13:

https://github.com/openresty/docker-openresty/blob/05a4d4d0cce6faca20932629e1789b431125ba70/alpine-apk/Dockerfile#L16

Meaning that right now, https://openresty.org/package/alpine/v3.12/main/ exists, but https://openresty.org/package/alpine/v3.13/main/ is a 404. I'm not sure what should be done there, but I suspect is a process that happens outside of this repo. Let me know if there is anything I can do to help with that.