### PR TITLE
Docker fat image reduction

### DIFF
--- a/alpine/Dockerfile.fat
+++ b/alpine/Dockerfile.fat
@@ -26,18 +26,18 @@ LABEL resty_luarocks_version="${RESTY_LUAROCKS_VERSION}"
 
 RUN apk add --no-cache --virtual .build-deps \
         perl-dev \
-    && apk add --no-cache \
         bash \
         build-base \
-        curl \
-        libintl \ 
         linux-headers \
         make \
         musl \
         outils-md5 \
         perl \
+        curl \
+    && apk add --no-cache \
         unzip \
         wget \
+        libintl \
     && cd /tmp \
     && curl -fSL https://luarocks.github.io/luarocks/releases/luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz -o luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
     && tar xzf luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \


### PR DESCRIPTION
almost 3 times smaller fat images by removing unused alpine packages
original size:
`REPOSITORY          TAG           IMAGE ID       CREATED              SIZE
test                latest        f3a4fb6875e7   About a minute ago   396MB
`
fix:
`REPOSITORY          TAG           IMAGE ID       CREATED          SIZE
test-fix-size       latest        6034bc75cd29   4 seconds ago    108MB
test                latest        f3a4fb6875e7   2 minutes ago    396MB
`