### PR TITLE
Fix restart error during build process for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## 1.25.3.1-2
+
+* Change base install image of `windows` to dotnet image
+* Fix syntax error in command instruction of `windows` build
+
 ## 1.25.3.1-1
 
  * Add `--with-http_v3_module` to build-from-source flavors

--- a/README.md
+++ b/README.md
@@ -499,8 +499,8 @@ docker build --build-arg RESTY_VERSION="1.13.6.2" -f windows/Dockerfile .
 
 | Key | Default | Description |
 :----- | :-----: |:----------- |
-|RESTY_INSTALL_BASE | "mcr.microsoft.com/windows/servercore" | The Windows Server Docker image name to download and install OpenResty with. |
-|RESTY_INSTALL_TAG  | "ltsc2019" | The Windows Server Docker image name to download and install OpenResty with. |
+|RESTY_INSTALL_BASE | "mcr.microsoft.com/dotnet/framework/runtime" | The Windows Server Docker image name to download and install OpenResty with. |
+|RESTY_INSTALL_TAG  | "4.8-windowsservercore-ltsc2019" | The Windows Server Docker image name to download and install OpenResty with. |
 |RESTY_IMAGE_BASE   | "mcr.microsoft.com/windows/nanoserver" | The Windows Server Docker image name to build `FROM` for final image. |
 |RESTY_IMAGE_TAG    | "1809" | The Windows Server Docker image tag to build `FROM` for final image. |
 |RESTY_VERSION      | 1.25.3.1 | The version of OpenResty to use. |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,13 +26,13 @@ deploy_script:
     if (${env:APPVEYOR_REPO_BRANCH} -eq "master") {
         docker tag ${env:DOCKER_ORG}:windows ${env:DOCKER_ORG}/openresty:windows
         docker push ${env:DOCKER_ORG}/openresty:windows
-        docker tag ${env:DOCKER_ORG}:windows ${env:DOCKER_ORG}/openresty:windows-2016
-        docker push ${env:DOCKER_ORG}/openresty:windows-2016
+        docker tag ${env:DOCKER_ORG}:windows ${env:DOCKER_ORG}/openresty:windows-2022
+        docker push ${env:DOCKER_ORG}/openresty:windows-2022
     }
 
     if (${env:APPVEYOR_REPO_TAG_NAME}) {
         docker tag ${env:DOCKER_ORG}:windows ${env:DOCKER_ORG}/openresty:${env:APPVEYOR_REPO_TAG_NAME}-windows
         docker push ${env:DOCKER_ORG}/openresty:${env:APPVEYOR_REPO_TAG_NAME}-windows
-        docker tag ${env:DOCKER_ORG}:windows ${env:DOCKER_ORG}/openresty:${env:APPVEYOR_REPO_TAG_NAME}-windows-2016
-        docker push ${env:DOCKER_ORG}/openresty:${env:APPVEYOR_REPO_TAG_NAME}-windows-2016
+        docker tag ${env:DOCKER_ORG}:windows ${env:DOCKER_ORG}/openresty:${env:APPVEYOR_REPO_TAG_NAME}-windows-2022
+        docker push ${env:DOCKER_ORG}/openresty:${env:APPVEYOR_REPO_TAG_NAME}-windows-2022
     }

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -2,8 +2,8 @@
 # Dockerfile - Windows
 # https://github.com/openresty/docker-openresty
 
-ARG RESTY_INSTALL_BASE="mcr.microsoft.com/windows/servercore"
-ARG RESTY_INSTALL_TAG="ltsc2019"
+ARG RESTY_INSTALL_BASE="mcr.microsoft.com/dotnet/framework/runtime"
+ARG RESTY_INSTALL_TAG="4.8-windowsservercore-ltsc2019"
 ARG RESTY_IMAGE_BASE="mcr.microsoft.com/windows/nanoserver"
 ARG RESTY_IMAGE_TAG="1809"
 
@@ -32,10 +32,10 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
 
 FROM "${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG}"
 
-ARG RESTY_INSTALL_BASE="mcr.microsoft.com/windows/servercore"
-ARG RESTY_INSTALL_TAG="ltsc2019"
-ARG RESTY_IMAGE_BASE="mcr.microsoft.com/windows/nanoserver"
-ARG RESTY_IMAGE_TAG="1809"
+ARG RESTY_INSTALL_BASE
+ARG RESTY_INSTALL_TAG
+ARG RESTY_IMAGE_BASE
+ARG RESTY_IMAGE_TAG
 ARG RESTY_VERSION="1.25.3.1"
 
 LABEL maintainer="Evan Wies <evan@neomantra.net>"
@@ -52,7 +52,7 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Strawberry\perl\bin;C:\openresty"
 USER ContainerUser
 
-CMD [ "nginx", "-g", "`"daemon off;`""]
+CMD ["nginx", "-g", "daemon off;"]
 
 COPY --from=downloader C:/dl/ C:/
 


### PR DESCRIPTION
When trying to install the .NET Framework manually, the image build process fails because .NET demands a system restart after installation. This interrupts the build process entirely, and no image can be built. Instead, a base image should be used that already has the .NET environment included in it, so that the framework installation process is skipped entirely.

Additionally, the command instruction has incorrect syntax, precisely the escaped quotation marks which should not be there.