### PR TITLE
Fixed bug where container cannot find openresty bin

### DIFF
--- a/bullseye/Dockerfile
+++ b/bullseye/Dockerfile
@@ -60,7 +60,7 @@ ENV PATH="$PATH:/usr/local/openresty${RESTY_DEB_FLAVOR}/luajit/bin:/usr/local/op
 COPY nginx.conf /usr/local/openresty${RESTY_DEB_FLAVOR}/nginx/conf/nginx.conf
 COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
-CMD ["/usr/bin/openresty", "-g", "daemon off;"]
+CMD ["openresty", "-g", "daemon off;"]
 
 # Use SIGQUIT instead of default SIGTERM to cleanly drain requests
 # See https://github.com/openresty/docker-openresty/blob/master/README.md#tips--pitfalls


### PR DESCRIPTION
Fixes issue #259 where the container fails to start when using RESTY_DEBUG_FLAVOR=-debug.

Explanation:
When using RESTY_DEBUG_FLAVOR=-debug, the file found in /usr/bin is **openresty-debug**. But that is just a symlink to the **openresty** binary that is already in the PATH, so we can just call **openresty** directly.