### PR TITLE
feature: Enable PCRE for the dockerfile builds on s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ jobs:
       arch: s390x
       stage: build
       script:
-      - ./docker_build_and_push_flavor.sh bionic-s390x bionic/Dockerfile --build-arg RESTY_PCRE_BUILD_OPTIONS="" --build-arg RESTY_PCRE_OPTIONS=""
+      - ./docker_build_and_push_flavor.sh bionic-s390x bionic/Dockerfile
 
     - name: Build Docker image for build-from-source flavor -- focal / aarch64
       arch: arm64
@@ -107,7 +107,7 @@ jobs:
       arch: s390x
       stage: build
       script:
-      - ./docker_build_and_push_flavor.sh focal-s390x focal/Dockerfile --build-arg RESTY_PCRE_BUILD_OPTIONS="" --build-arg RESTY_PCRE_OPTIONS=""
+      - ./docker_build_and_push_flavor.sh focal-s390x focal/Dockerfile
 
     - name: Build Docker image for build-from-source flavor -- jammy / aarch64
       arch: arm64
@@ -125,7 +125,7 @@ jobs:
       arch: s390x
       stage: build
       script:
-      - ./docker_build_and_push_flavor.sh jammy-s390x jammy/Dockerfile --build-arg RESTY_PCRE_BUILD_OPTIONS="" --build-arg RESTY_PCRE_OPTIONS=""
+      - ./docker_build_and_push_flavor.sh jammy-s390x jammy/Dockerfile
 
     - name: Build Docker image for build-from-source flavor -- noble / aarch64
       arch: arm64
@@ -143,7 +143,7 @@ jobs:
       arch: s390x
       stage: build
       script:
-      - ./docker_build_and_push_flavor.sh noble-s390x noble/Dockerfile --build-arg RESTY_PCRE_BUILD_OPTIONS="" --build-arg RESTY_PCRE_OPTIONS=""
+      - ./docker_build_and_push_flavor.sh noble-s390x noble/Dockerfile
 
 ###############################################################################
 # Build From OpenResty Upstream Flavors


### PR DESCRIPTION
Hello,
The Community is using PCRE 10.x series since [v1.27.1.1](https://github.com/openresty/docker-openresty/commit/78d64677f91e01912fe13e62473d1322844ac704#diff-c103cad68cceba4d779da1d452f98b8778121602c952c8f7d0107c98a8b938e3) and its supported on s390x.

I've built all the Dockerfiles on s390x with the `PCRE`-flags enabled and the builds are Successful.
Flavors built - Bionic, Focal, Jammy, Noble.

So adding the PCRE build options in the Build-from-source Dockerfiles.
This will also resolve the Issue - [#834](https://github.com/openresty/openresty/issues/834)