### PR TITLE
Guard source builds against CVE-2026-42945

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 `docker-openresty` Changelog
 ============================
 
+## Unreleased
+
+ * Add a build-time guard for the CVE-2026-42945 NGINX rewrite module fix in source-built images.
+
  ## 1.29.2.4-0 (2026-05-18)
 
 **Only `build-from-source` and `alpine-apk` flavors are included in this release.**  Thanks to the OpenResty maintainers.

--- a/alma/Dockerfile
+++ b/alma/Dockerfile
@@ -112,6 +112,7 @@ LABEL resty_eval_post_make="${RESTY_EVAL_POST_MAKE}"
 LABEL resty_luajit_options="${RESTY_LUAJIT_OPTIONS}"
 LABEL resty_pcre_options="${RESTY_PCRE_OPTIONS}"
 
+COPY scripts/apply-nginx-cve-2026-42945-fix.sh /tmp/apply-nginx-cve-2026-42945-fix.sh
 
 RUN microdnf install -y \
         curl \
@@ -155,6 +156,7 @@ RUN microdnf install -y \
     && curl -fSL https://openresty.org/download/openresty-${RESTY_VERSION}.tar.gz -o openresty-${RESTY_VERSION}.tar.gz \
     && tar xzf openresty-${RESTY_VERSION}.tar.gz \
     && cd /tmp/openresty-${RESTY_VERSION} \
+    && sh /tmp/apply-nginx-cve-2026-42945-fix.sh \
     && if [ -n "${RESTY_EVAL_POST_DOWNLOAD_PRE_CONFIGURE}" ]; then eval $(echo ${RESTY_EVAL_POST_DOWNLOAD_PRE_CONFIGURE}); fi \
     && eval ./configure -j${RESTY_J} ${_RESTY_CONFIG_DEPS} ${RESTY_CONFIG_OPTIONS} ${RESTY_CONFIG_OPTIONS_MORE} ${RESTY_LUAJIT_OPTIONS} ${RESTY_PCRE_OPTIONS} \
     && if [ -n "${RESTY_EVAL_PRE_MAKE}" ]; then eval $(echo ${RESTY_EVAL_PRE_MAKE}); fi \
@@ -177,6 +179,7 @@ RUN microdnf install -y \
         openssl-${RESTY_OPENSSL_VERSION}.tar.gz openssl-${RESTY_OPENSSL_VERSION} \
         pcre2-${RESTY_PCRE_VERSION}.tar.gz pcre2-${RESTY_PCRE_VERSION} \
         openresty-${RESTY_VERSION}.tar.gz openresty-${RESTY_VERSION} \
+        apply-nginx-cve-2026-42945-fix.sh \
     && if [ -n "${RESTY_ADD_PACKAGE_BUILDDEPS}" ]; then DEBIAN_FRONTEND=noninteractive apt-get remove -y --purge ${RESTY_ADD_PACKAGE_BUILDDEPS} ; fi \
     && microdnf clean all \
     && mkdir -p /var/run/openresty \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -113,6 +113,8 @@ LABEL resty_strip_binaries="${RESTY_STRIP_BINARIES}"
 LABEL resty_luajit_options="${RESTY_LUAJIT_OPTIONS}"
 LABEL resty_pcre_options="${RESTY_PCRE_OPTIONS}"
 
+COPY scripts/apply-nginx-cve-2026-42945-fix.sh /tmp/apply-nginx-cve-2026-42945-fix.sh
+
 RUN apk add --no-cache --virtual .build-deps \
         build-base \
         binutils \
@@ -177,6 +179,7 @@ RUN apk add --no-cache --virtual .build-deps \
     && curl -fSL https://openresty.org/download/openresty-${RESTY_VERSION}.tar.gz -o openresty-${RESTY_VERSION}.tar.gz \
     && tar xzf openresty-${RESTY_VERSION}.tar.gz \
     && cd /tmp/openresty-${RESTY_VERSION} \
+    && sh /tmp/apply-nginx-cve-2026-42945-fix.sh \
     && if [ -n "${RESTY_EVAL_POST_DOWNLOAD_PRE_CONFIGURE}" ]; then eval $(echo ${RESTY_EVAL_POST_DOWNLOAD_PRE_CONFIGURE}); fi \
     && eval ./configure -j${RESTY_J} ${_RESTY_CONFIG_DEPS} ${RESTY_CONFIG_OPTIONS} ${RESTY_CONFIG_OPTIONS_MORE} ${RESTY_LUAJIT_OPTIONS} ${RESTY_PCRE_OPTIONS} \
     && if [ -n "${RESTY_EVAL_PRE_MAKE}" ]; then eval $(echo ${RESTY_EVAL_PRE_MAKE}); fi \
@@ -188,6 +191,7 @@ RUN apk add --no-cache --virtual .build-deps \
         openssl-${RESTY_OPENSSL_VERSION}.tar.gz openssl-${RESTY_OPENSSL_VERSION} \
         pcre2-${RESTY_PCRE_VERSION}.tar.gz pcre2-${RESTY_PCRE_VERSION} \
         openresty-${RESTY_VERSION}.tar.gz openresty-${RESTY_VERSION} \
+        apply-nginx-cve-2026-42945-fix.sh \
     && if [ -n "${RESTY_STRIP_BINARIES}" ]; then \
         echo 'stripping OpenResty binaries' \
         && rm -Rf /usr/local/openresty/openssl3/bin/c_rehash /usr/local/openresty/openssl3/lib/*.a /usr/local/openresty/openssl3/include \

--- a/jammy/Dockerfile
+++ b/jammy/Dockerfile
@@ -112,6 +112,7 @@ LABEL resty_eval_post_make="${RESTY_EVAL_POST_MAKE}"
 LABEL resty_luajit_options="${RESTY_LUAJIT_OPTIONS}"
 LABEL resty_pcre_options="${RESTY_PCRE_OPTIONS}"
 
+COPY scripts/apply-nginx-cve-2026-42945-fix.sh /tmp/apply-nginx-cve-2026-42945-fix.sh
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -173,6 +174,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && curl -fSL https://openresty.org/download/openresty-${RESTY_VERSION}.tar.gz -o openresty-${RESTY_VERSION}.tar.gz \
     && tar xzf openresty-${RESTY_VERSION}.tar.gz \
     && cd /tmp/openresty-${RESTY_VERSION} \
+    && sh /tmp/apply-nginx-cve-2026-42945-fix.sh \
     && if [ -n "${RESTY_EVAL_POST_DOWNLOAD_PRE_CONFIGURE}" ]; then eval $(echo ${RESTY_EVAL_POST_DOWNLOAD_PRE_CONFIGURE}); fi \
     && eval ./configure -j${RESTY_J} ${_RESTY_CONFIG_DEPS} ${RESTY_CONFIG_OPTIONS} ${RESTY_CONFIG_OPTIONS_MORE} ${RESTY_LUAJIT_OPTIONS} ${RESTY_PCRE_OPTIONS} \
     && if [ -n "${RESTY_EVAL_PRE_MAKE}" ]; then eval $(echo ${RESTY_EVAL_PRE_MAKE}); fi \
@@ -183,6 +185,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
         openssl-${RESTY_OPENSSL_VERSION}.tar.gz openssl-${RESTY_OPENSSL_VERSION} \
         pcre2-${RESTY_PCRE_VERSION}.tar.gz pcre2-${RESTY_PCRE_VERSION} \
         openresty-${RESTY_VERSION}.tar.gz openresty-${RESTY_VERSION} \
+        apply-nginx-cve-2026-42945-fix.sh \
     && curl -fSL https://luarocks.github.io/luarocks/releases/luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz -o luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
     && tar xzf luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
     && cd luarocks-${RESTY_LUAROCKS_VERSION} \

--- a/noble/Dockerfile
+++ b/noble/Dockerfile
@@ -112,6 +112,7 @@ LABEL resty_eval_post_make="${RESTY_EVAL_POST_MAKE}"
 LABEL resty_luajit_options="${RESTY_LUAJIT_OPTIONS}"
 LABEL resty_pcre_options="${RESTY_PCRE_OPTIONS}"
 
+COPY scripts/apply-nginx-cve-2026-42945-fix.sh /tmp/apply-nginx-cve-2026-42945-fix.sh
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -173,6 +174,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && curl -fSL https://openresty.org/download/openresty-${RESTY_VERSION}.tar.gz -o openresty-${RESTY_VERSION}.tar.gz \
     && tar xzf openresty-${RESTY_VERSION}.tar.gz \
     && cd /tmp/openresty-${RESTY_VERSION} \
+    && sh /tmp/apply-nginx-cve-2026-42945-fix.sh \
     && if [ -n "${RESTY_EVAL_POST_DOWNLOAD_PRE_CONFIGURE}" ]; then eval $(echo ${RESTY_EVAL_POST_DOWNLOAD_PRE_CONFIGURE}); fi \
     && eval ./configure -j${RESTY_J} ${_RESTY_CONFIG_DEPS} ${RESTY_CONFIG_OPTIONS} ${RESTY_CONFIG_OPTIONS_MORE} ${RESTY_LUAJIT_OPTIONS} ${RESTY_PCRE_OPTIONS} \
     && if [ -n "${RESTY_EVAL_PRE_MAKE}" ]; then eval $(echo ${RESTY_EVAL_PRE_MAKE}); fi \
@@ -183,6 +185,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
         openssl-${RESTY_OPENSSL_VERSION}.tar.gz openssl-${RESTY_OPENSSL_VERSION} \
         pcre2-${RESTY_PCRE_VERSION}.tar.gz pcre2-${RESTY_PCRE_VERSION} \
         openresty-${RESTY_VERSION}.tar.gz openresty-${RESTY_VERSION} \
+        apply-nginx-cve-2026-42945-fix.sh \
     && curl -fSL https://luarocks.github.io/luarocks/releases/luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz -o luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
     && tar xzf luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
     && cd luarocks-${RESTY_LUAROCKS_VERSION} \

--- a/restyrepo/Dockerfile
+++ b/restyrepo/Dockerfile
@@ -113,6 +113,7 @@ LABEL resty_eval_post_make="${RESTY_EVAL_POST_MAKE}"
 LABEL resty_luajit_options="${RESTY_LUAJIT_OPTIONS}"
 LABEL resty_pcre_options="${RESTY_PCRE_OPTIONS}"
 
+COPY scripts/apply-nginx-cve-2026-42945-fix.sh /tmp/apply-nginx-cve-2026-42945-fix.sh
 
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
@@ -185,6 +186,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && tar xzf "openresty-${RESTY_VERSION}.tar.gz" \
     && mv openresty-*/ "openresty-${RESTY_VERSION}" \
     && cd /tmp/openresty-${RESTY_VERSION} \
+    && sh /tmp/apply-nginx-cve-2026-42945-fix.sh \
     && if [ -n "${RESTY_EVAL_POST_DOWNLOAD_PRE_CONFIGURE}" ]; then eval $(echo ${RESTY_EVAL_POST_DOWNLOAD_PRE_CONFIGURE}); fi \
     && eval ./configure -j${RESTY_J} ${_RESTY_CONFIG_DEPS} ${RESTY_CONFIG_OPTIONS} ${RESTY_CONFIG_OPTIONS_MORE} ${RESTY_LUAJIT_OPTIONS} ${RESTY_PCRE_OPTIONS} \
     && if [ -n "${RESTY_EVAL_PRE_MAKE}" ]; then eval $(echo ${RESTY_EVAL_PRE_MAKE}); fi \
@@ -195,6 +197,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
         openssl-${RESTY_OPENSSL_VERSION}.tar.gz openssl-${RESTY_OPENSSL_VERSION} \
         pcre2-${RESTY_PCRE_VERSION}.tar.gz pcre2-${RESTY_PCRE_VERSION} \
         openresty-${RESTY_VERSION}.tar.gz openresty-${RESTY_VERSION} openresty_src \
+        apply-nginx-cve-2026-42945-fix.sh \
     && curl -fSL https://luarocks.github.io/luarocks/releases/luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz -o luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
     && tar xzf luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
     && cd luarocks-${RESTY_LUAROCKS_VERSION} \

--- a/scripts/apply-nginx-cve-2026-42945-fix.sh
+++ b/scripts/apply-nginx-cve-2026-42945-fix.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -eu
+
+script_file="$(find bundle -path '*/src/http/ngx_http_script.c' -type f | head -n 1)"
+
+if [ -z "$script_file" ]; then
+    echo "error: bundled nginx ngx_http_script.c not found" >&2
+    exit 1
+fi
+
+perl -0pi -e '
+    my $needle = "    r = e->request;\n\n    e->quote = 0;";
+    my $replacement = "    r = e->request;\n\n    e->is_args = 0;\n    e->quote = 0;";
+    our $patched;
+    our $present;
+
+    my $start = index($_, "ngx_http_script_regex_end_code(ngx_http_script_engine_t *e)");
+    die "failed to find ngx_http_script_regex_end_code()\n" if $start < 0;
+
+    my $end = index($_, "\n}\n\n\nvoid\n", $start);
+    die "failed to find end of ngx_http_script_regex_end_code()\n" if $end < 0;
+
+    my $function = substr($_, $start, $end - $start);
+
+    if ($function =~ /^\s*e->is_args = 0;/m) {
+        $present = 1;
+        next;
+    }
+
+    die "unexpected ngx_http_script_regex_end_code() body\n"
+        unless $function =~ /\Q$needle\E/;
+
+    substr($function, index($function, $needle), length($needle)) = $replacement;
+    substr($_, $start, $end - $start) = $function;
+    $patched = 1;
+
+    END {
+        if ($patched) {
+            print "Applied CVE-2026-42945 fix to $ARGV\n";
+        } elsif ($present) {
+            print "CVE-2026-42945 fix already present in $ARGV\n";
+        }
+    }
+' "$script_file"
+
+grep -q '^[[:space:]]*e->is_args = 0;' "$script_file"


### PR DESCRIPTION
## Summary
- Add an idempotent build-time guard for the CVE-2026-42945 NGINX rewrite module fix.
- Apply the guard to source-built image flavors.
- Keep current OpenResty 1.29.2.4 builds unchanged when the bundled NGINX source already contains the upstream fix.

## Notes
NGINX 1.30.1 added the `ngx_http_script_regex_end_code()` fix for CVE-2026-42945. The OpenResty 1.29.2.4 source package already includes the same guard in its bundled NGINX source, so this change is intentionally idempotent: current builds report that the fix is already present, while older or overridden source versions can be patched before `./configure` runs.

## Test Plan
- `sh -n scripts/apply-nginx-cve-2026-42945-fix.sh`
- `git diff --check`
- Verified the guard is a no-op against the OpenResty 1.29.2.4 bundled NGINX source.
- Verified the guard inserts the fix once, then becomes a no-op, against an unfixed NGINX 1.29.2 source fixture.
- Attempted `docker build -f alpine/Dockerfile .`; Docker reached the copied guard script layer, then failed before compilation due to transient Alpine APK index DNS errors in the local build environment.
