### PR TITLE
Generate tags for major and major+minor versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -417,6 +417,8 @@ jobs:
             type=raw,value=${{ matrix.flavor }}-${{ matrix.arch }},enable=${{ github.ref == 'refs/heads/master' }}
             type=ref,event=tag,suffix=-${{ matrix.flavor }}-${{ matrix.arch }}
             type=match,pattern=^(.*)-[0-9]+$,group=1,suffix=-${{ matrix.flavor }}-${{ matrix.arch }}
+            type=match,pattern=^([0-9]+)\.[0-9]+\.[0-9]+$,group=1,suffix=-${{ matrix.flavor }}-${{ matrix.arch }}
+            type=match,pattern=^([0-9]+\.[0-9]+)\.[0-9]+$,group=1,suffix=-${{ matrix.flavor }}-${{ matrix.arch }}
 
       - name: Build and push
         uses: docker/build-push-action@v7


### PR DESCRIPTION
Hi! Just a suggestion.

I think it would be great to have image tags such as `1-alpine` and `1.31-alpine` in addition to the current tags. It makes upgrades and maintenance easier.

Thanks!